### PR TITLE
feat: add calldata decoder service

### DIFF
--- a/scripts/test-calldata-decoder.ts
+++ b/scripts/test-calldata-decoder.ts
@@ -1,0 +1,96 @@
+/**
+ * Manual test script for calldata decoder
+ * Run with: npx tsx scripts/test-calldata-decoder.ts
+ */
+
+import { decodeCalldata, extractSelector } from '../src/services/decoder/calldata-decoder';
+
+// Test data - known function calls
+const testCases = [
+  {
+    name: 'ERC20 transfer',
+    // transfer(address,uint256) with to=0x1234...5678, amount=1000000
+    data: '0xa9059cbb0000000000000000000000001234567890123456789012345678901234567890000000000000000000000000000000000000000000000000000000000000000f4240',
+    expectedSelector: '0xa9059cbb',
+    expectedFunction: 'transfer',
+  },
+  {
+    name: 'ERC20 approve',
+    // approve(address,uint256) with spender=0xabcd...ef01, amount=max
+    data: '0x095ea7b3000000000000000000000000abcdef0123456789abcdef0123456789abcdef01ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+    expectedSelector: '0x095ea7b3',
+    expectedFunction: 'approve',
+  },
+  {
+    name: 'WETH deposit',
+    // deposit() - no args
+    data: '0xd0e30db0',
+    expectedSelector: '0xd0e30db0',
+    expectedFunction: 'deposit',
+  },
+  {
+    name: 'Unknown selector',
+    data: '0xdeadbeef0000000000000000000000000000000000000000000000000000000000000001',
+    expectedSelector: '0xdeadbeef',
+    expectedFunction: null,
+  },
+  {
+    name: 'Too short calldata',
+    data: '0xa905',
+    expectedSelector: null,
+    expectedFunction: null,
+  },
+  {
+    name: 'ERC20 transferFrom',
+    // transferFrom(address,address,uint256)
+    data: '0x23b872dd000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa000000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb0000000000000000000000000000000000000000000000000000000000000064',
+    expectedSelector: '0x23b872dd',
+    expectedFunction: 'transferFrom',
+  },
+  {
+    name: 'WETH withdraw',
+    // withdraw(uint256)
+    data: '0x2e1a7d4d0000000000000000000000000000000000000000000000000de0b6b3a7640000',
+    expectedSelector: '0x2e1a7d4d',
+    expectedFunction: 'withdraw',
+  },
+];
+
+console.log('=== Calldata Decoder Tests ===\n');
+
+let passed = 0;
+let failed = 0;
+
+for (const tc of testCases) {
+  console.log(`Test: ${tc.name}`);
+  console.log(`  Input: ${tc.data.slice(0, 20)}...`);
+
+  const selector = extractSelector(tc.data as `0x${string}`);
+  const selectorMatch = selector === tc.expectedSelector;
+
+  console.log(`  Selector: ${selector} (expected: ${tc.expectedSelector}) ${selectorMatch ? '✓' : '✗'}`);
+
+  const decoded = decodeCalldata(tc.data as `0x${string}`);
+  const functionMatch = decoded?.name === tc.expectedFunction || (decoded === null && tc.expectedFunction === null);
+
+  console.log(`  Function: ${decoded?.name ?? 'null'} (expected: ${tc.expectedFunction}) ${functionMatch ? '✓' : '✗'}`);
+
+  if (decoded) {
+    console.log(`  Signature: ${decoded.signature}`);
+    console.log(`  Args: ${decoded.args.map(a => `${a.name}=${a.formatted}`).join(', ')}`);
+  }
+
+  if (selectorMatch && functionMatch) {
+    passed++;
+    console.log('  Result: PASS\n');
+  } else {
+    failed++;
+    console.log('  Result: FAIL\n');
+  }
+}
+
+console.log('=== Summary ===');
+console.log(`Passed: ${passed}/${testCases.length}`);
+console.log(`Failed: ${failed}/${testCases.length}`);
+
+process.exit(failed > 0 ? 1 : 0);

--- a/src/services/decoder/calldata-decoder.ts
+++ b/src/services/decoder/calldata-decoder.ts
@@ -1,4 +1,98 @@
-// Placeholder for calldata decoder - implemented in Issue #6
-export function decodeCalldata() {
-  // TODO: Implement calldata decoder
+import { decodeFunctionData, toFunctionSignature } from 'viem';
+import type { Hex, DecodedFunctionCall, DecodedArgument } from '@/types';
+import { getBySelector } from '@/services/abi';
+
+/**
+ * Extract 4-byte function selector from calldata.
+ */
+export function extractSelector(data: Hex): Hex | null {
+  if (data.length < 10) {
+    return null; // Need at least 0x + 4 bytes (8 hex chars)
+  }
+  return data.slice(0, 10).toLowerCase() as Hex;
+}
+
+/**
+ * Decode calldata into function name and parameters.
+ * Returns null for unknown selectors or decode failures.
+ */
+export function decodeCalldata(data: Hex): DecodedFunctionCall | null {
+  const selector = extractSelector(data);
+  if (!selector) {
+    return null;
+  }
+
+  const abiItems = getBySelector(selector);
+  if (abiItems.length === 0) {
+    return null; // Unknown selector
+  }
+
+  // Try each matching ABI until one succeeds
+  for (const abiItem of abiItems) {
+    try {
+      const abi = [abiItem] as const;
+      const decoded = decodeFunctionData({ abi, data });
+
+      const signature = toFunctionSignature(abiItem);
+      const args = formatArguments(abiItem, decoded.args);
+
+      return {
+        name: decoded.functionName,
+        signature,
+        selector,
+        args,
+        abi,
+      };
+    } catch {
+      // Try next ABI if this one fails
+      continue;
+    }
+  }
+
+  return null; // All ABIs failed to decode
+}
+
+/**
+ * Format decoded arguments into DecodedArgument array.
+ */
+function formatArguments(
+  abiItem: { inputs?: readonly { name: string; type: string }[] },
+  args: readonly unknown[] | undefined
+): DecodedArgument[] {
+  if (!args || !abiItem.inputs) {
+    return [];
+  }
+
+  return abiItem.inputs.map((input, index) => ({
+    name: input.name || `arg${index}`,
+    type: input.type,
+    value: args[index],
+    formatted: formatValue(args[index], input.type),
+  }));
+}
+
+/**
+ * Format a value for display based on its type.
+ */
+function formatValue(value: unknown, type: string): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((v) => formatValue(v, type.replace('[]', ''))).join(', ')}]`;
+  }
+
+  if (typeof value === 'object') {
+    // Handle tuple types
+    return JSON.stringify(value, (_, v) =>
+      typeof v === 'bigint' ? v.toString() : v
+    );
+  }
+
+  return String(value);
 }


### PR DESCRIPTION
- Extract 4-byte selector from calldata
- Look up ABI from registry by selector
- Decode with viem decodeFunctionData
- Return DecodedFunctionCall with formatted arguments
- Handle unknown selectors gracefully (return null)
- Add test script with 7 passing test cases

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)