### PR TITLE
feat: add protocol registry with contract labels

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
-  { ignores: ['dist'] },
+  { ignores: ['dist', '.vite', 'node_modules'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],

--- a/scripts/test-protocol-registry.ts
+++ b/scripts/test-protocol-registry.ts
@@ -1,0 +1,112 @@
+/**
+ * Manual test script for protocol registry
+ * Run with: npx tsx scripts/test-protocol-registry.ts
+ */
+
+import { getProtocol, listProtocols, getProtocolContracts } from '../src/services/protocol';
+import type { Address, ChainId } from '../src/types';
+
+const testCases = [
+  {
+    name: 'WETH on Ethereum',
+    address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2' as Address,
+    chainId: 1 as ChainId,
+    expectedProtocol: 'weth',
+    expectedContract: 'WETH9',
+  },
+  {
+    name: 'Uniswap V2 Router (lowercase)',
+    address: '0x7a250d5630b4cf539739df2c5dacb4c659f2488d' as Address,
+    chainId: 1 as ChainId,
+    expectedProtocol: 'uniswap',
+    expectedContract: 'Uniswap V2: Router 2',
+  },
+  {
+    name: 'Uniswap V3 Router 2',
+    address: '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45' as Address,
+    chainId: 1 as ChainId,
+    expectedProtocol: 'uniswap',
+    expectedContract: 'Uniswap V3: Router 2',
+  },
+  {
+    name: 'SushiSwap Router',
+    address: '0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F' as Address,
+    chainId: 1 as ChainId,
+    expectedProtocol: 'sushiswap',
+    expectedContract: 'SushiSwap: Router',
+  },
+  {
+    name: '1inch Aggregation Router',
+    address: '0x1111111254EEB25477B68fb85Ed929f73A960582' as Address,
+    chainId: 1 as ChainId,
+    expectedProtocol: '1inch',
+    expectedContract: '1inch V5: Aggregation Router',
+  },
+  {
+    name: 'Unknown address',
+    address: '0xDeadBeefDeadBeefDeadBeefDeadBeefDeadBeef' as Address,
+    chainId: 1 as ChainId,
+    expectedProtocol: null,
+    expectedContract: null,
+  },
+  {
+    name: 'Known address on unsupported chain',
+    address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2' as Address,
+    chainId: 137 as ChainId, // Polygon
+    expectedProtocol: null,
+    expectedContract: null,
+  },
+];
+
+console.log('=== Protocol Registry Tests ===\n');
+
+let passed = 0;
+let failed = 0;
+
+for (const tc of testCases) {
+  console.log(`Test: ${tc.name}`);
+  console.log(`  Address: ${tc.address.slice(0, 10)}...`);
+  console.log(`  ChainId: ${tc.chainId}`);
+
+  const result = getProtocol(tc.address, tc.chainId);
+
+  const protocolMatch = result?.protocol.id === tc.expectedProtocol ||
+    (result === null && tc.expectedProtocol === null);
+  const contractMatch = result?.contractName === tc.expectedContract ||
+    (result === null && tc.expectedContract === null);
+
+  console.log(`  Protocol: ${result?.protocol.id ?? 'null'} (expected: ${tc.expectedProtocol}) ${protocolMatch ? '✓' : '✗'}`);
+  console.log(`  Contract: ${result?.contractName ?? 'null'} (expected: ${tc.expectedContract}) ${contractMatch ? '✓' : '✗'}`);
+
+  if (protocolMatch && contractMatch) {
+    passed++;
+    console.log('  Result: PASS\n');
+  } else {
+    failed++;
+    console.log('  Result: FAIL\n');
+  }
+}
+
+// Test listProtocols
+console.log('=== listProtocols Test ===');
+const protocols = listProtocols(1);
+console.log(`Found ${protocols.length} unique protocols on Ethereum:`);
+protocols.forEach(p => console.log(`  - ${p.name} (${p.id})`));
+const listProtocolsPass = protocols.length >= 5; // We defined 5 protocols
+console.log(`Result: ${listProtocolsPass ? 'PASS' : 'FAIL'}\n`);
+if (listProtocolsPass) passed++; else failed++;
+
+// Test getProtocolContracts
+console.log('=== getProtocolContracts Test ===');
+const uniswapContracts = getProtocolContracts('uniswap', 1);
+console.log(`Found ${uniswapContracts.length} Uniswap contracts on Ethereum:`);
+uniswapContracts.forEach(c => console.log(`  - ${c.contractName}`));
+const protocolContractsPass = uniswapContracts.length >= 4; // We defined 4 Uniswap contracts
+console.log(`Result: ${protocolContractsPass ? 'PASS' : 'FAIL'}\n`);
+if (protocolContractsPass) passed++; else failed++;
+
+console.log('=== Summary ===');
+console.log(`Passed: ${passed}/${passed + failed}`);
+console.log(`Failed: ${failed}/${passed + failed}`);
+
+process.exit(failed > 0 ? 1 : 0);

--- a/src/data/contracts/ethereum.ts
+++ b/src/data/contracts/ethereum.ts
@@ -1,5 +1,95 @@
-// Placeholder for Ethereum mainnet contracts - implemented in Issue #7
-import type { ContractLabel } from '@/types';
+import type { ContractLabel, ProtocolInfo } from '@/types';
 
-// TODO: Implement contract registry in Issue #7
-export const ETHEREUM_CONTRACTS: ContractLabel[] = [];
+// Protocol definitions
+const UNISWAP: ProtocolInfo = {
+  id: 'uniswap',
+  name: 'Uniswap',
+  website: 'https://uniswap.org',
+};
+
+const SUSHISWAP: ProtocolInfo = {
+  id: 'sushiswap',
+  name: 'SushiSwap',
+  website: 'https://sushi.com',
+};
+
+const WETH_PROTOCOL: ProtocolInfo = {
+  id: 'weth',
+  name: 'Wrapped Ether',
+};
+
+const ONEINCH: ProtocolInfo = {
+  id: '1inch',
+  name: '1inch',
+  website: 'https://1inch.io',
+};
+
+const CURVE: ProtocolInfo = {
+  id: 'curve',
+  name: 'Curve Finance',
+  website: 'https://curve.fi',
+};
+
+// Ethereum mainnet contracts (chainId: 1)
+export const ETHEREUM_CONTRACTS: ContractLabel[] = [
+  // WETH
+  {
+    address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+    chainId: 1,
+    protocol: WETH_PROTOCOL,
+    contractName: 'WETH9',
+  },
+  // Uniswap V2
+  {
+    address: '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D',
+    chainId: 1,
+    protocol: UNISWAP,
+    contractName: 'Uniswap V2: Router 2',
+  },
+  {
+    address: '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f',
+    chainId: 1,
+    protocol: UNISWAP,
+    contractName: 'Uniswap V2: Factory',
+  },
+  // Uniswap V3
+  {
+    address: '0xE592427A0AEce92De3Edee1F18E0157C05861564',
+    chainId: 1,
+    protocol: UNISWAP,
+    contractName: 'Uniswap V3: Router',
+  },
+  {
+    address: '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45',
+    chainId: 1,
+    protocol: UNISWAP,
+    contractName: 'Uniswap V3: Router 2',
+  },
+  {
+    address: '0x1F98431c8aD98523631AE4a59f267346ea31F984',
+    chainId: 1,
+    protocol: UNISWAP,
+    contractName: 'Uniswap V3: Factory',
+  },
+  // SushiSwap
+  {
+    address: '0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F',
+    chainId: 1,
+    protocol: SUSHISWAP,
+    contractName: 'SushiSwap: Router',
+  },
+  // 1inch
+  {
+    address: '0x1111111254EEB25477B68fb85Ed929f73A960582',
+    chainId: 1,
+    protocol: ONEINCH,
+    contractName: '1inch V5: Aggregation Router',
+  },
+  // Curve
+  {
+    address: '0x99a58482BD75cbab83b27EC03CA68fF489b5788f',
+    chainId: 1,
+    protocol: CURVE,
+    contractName: 'Curve: Router',
+  },
+];

--- a/src/data/contracts/index.ts
+++ b/src/data/contracts/index.ts
@@ -1,2 +1,53 @@
-// Placeholder for contract registries - implemented in Issue #7
-export * from './ethereum';
+import type { Address, ChainId, ContractLabel } from '@/types';
+import { ETHEREUM_CONTRACTS } from './ethereum';
+
+export { ETHEREUM_CONTRACTS } from './ethereum';
+
+// Combined registry of all contracts by chainId
+const CONTRACT_REGISTRY: Map<ChainId, Map<Address, ContractLabel>> = new Map();
+
+// Build index for Ethereum mainnet
+function buildIndex(contracts: ContractLabel[]): Map<Address, ContractLabel> {
+  const index = new Map<Address, ContractLabel>();
+  for (const contract of contracts) {
+    // Normalize address to lowercase for case-insensitive lookup
+    const normalizedAddress = contract.address.toLowerCase() as Address;
+    index.set(normalizedAddress, contract);
+  }
+  return index;
+}
+
+CONTRACT_REGISTRY.set(1, buildIndex(ETHEREUM_CONTRACTS));
+
+/**
+ * Look up a contract by address and chainId.
+ */
+export function getContract(
+  address: Address,
+  chainId: ChainId
+): ContractLabel | null {
+  const chainContracts = CONTRACT_REGISTRY.get(chainId);
+  if (!chainContracts) {
+    return null;
+  }
+  const normalizedAddress = address.toLowerCase() as Address;
+  return chainContracts.get(normalizedAddress) ?? null;
+}
+
+/**
+ * Check if an address is a known contract.
+ */
+export function isKnownContract(address: Address, chainId: ChainId): boolean {
+  return getContract(address, chainId) !== null;
+}
+
+/**
+ * Get all contracts for a chain.
+ */
+export function getContractsByChain(chainId: ChainId): ContractLabel[] {
+  const chainContracts = CONTRACT_REGISTRY.get(chainId);
+  if (!chainContracts) {
+    return [];
+  }
+  return Array.from(chainContracts.values());
+}

--- a/src/services/protocol/index.ts
+++ b/src/services/protocol/index.ts
@@ -1,4 +1,42 @@
-// Placeholder for protocol registry service - implemented in Issue #7
-export function getProtocol() {
-  // TODO: Implement protocol registry
+import type { Address, ChainId, ContractLabel, ProtocolInfo } from '@/types';
+import { getContract, getContractsByChain } from '@/data/contracts';
+
+/**
+ * Get protocol information for a contract address.
+ * Returns ContractLabel with protocol info, or null if unknown.
+ */
+export function getProtocol(
+  address: Address,
+  chainId: ChainId
+): ContractLabel | null {
+  return getContract(address, chainId);
+}
+
+/**
+ * Get all unique protocols for a chain.
+ */
+export function listProtocols(chainId: ChainId): ProtocolInfo[] {
+  const contracts = getContractsByChain(chainId);
+  const seen = new Set<string>();
+  const protocols: ProtocolInfo[] = [];
+
+  for (const contract of contracts) {
+    if (!seen.has(contract.protocol.id)) {
+      seen.add(contract.protocol.id);
+      protocols.push(contract.protocol);
+    }
+  }
+
+  return protocols;
+}
+
+/**
+ * Get all contracts for a specific protocol on a chain.
+ */
+export function getProtocolContracts(
+  protocolId: string,
+  chainId: ChainId
+): ContractLabel[] {
+  const contracts = getContractsByChain(chainId);
+  return contracts.filter((c) => c.protocol.id === protocolId);
 }


### PR DESCRIPTION
- Add Ethereum mainnet contracts: WETH, Uniswap V2/V3, SushiSwap, 1inch, Curve
- Implement getProtocol(address, chainId) returning ContractLabel
- Add listProtocols() and getProtocolContracts() helpers
- Fix eslint config to ignore .vite cache directory
- Add test script with 9 passing test cases

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)