### PR TITLE
feat: add token registry service with Uniswap Token List

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
-  { ignores: ['dist'] },
+  { ignores: ['dist', '.vite', 'node_modules'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],

--- a/scripts/test-token-registry.ts
+++ b/scripts/test-token-registry.ts
@@ -1,0 +1,107 @@
+/**
+ * Manual test script for token registry
+ * Run with: npx tsx scripts/test-token-registry.ts
+ */
+
+import { formatAmount } from '../src/services/token';
+import type { TokenInfo, Address, ChainId } from '../src/types';
+
+// Mock token for testing formatAmount
+const mockUSDC: TokenInfo = {
+  address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as Address,
+  chainId: 1 as ChainId,
+  symbol: 'USDC',
+  name: 'USD Coin',
+  decimals: 6,
+};
+
+const mockWETH: TokenInfo = {
+  address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' as Address,
+  chainId: 1 as ChainId,
+  symbol: 'WETH',
+  name: 'Wrapped Ether',
+  decimals: 18,
+};
+
+const MAX_UINT256 = 2n ** 256n - 1n;
+
+const formatTestCases = [
+  {
+    name: 'USDC: 1,000,000 (1 USDC)',
+    amount: 1_000_000n,
+    token: mockUSDC,
+    expected: '1 USDC',
+  },
+  {
+    name: 'USDC: 1,500,000 (1.5 USDC)',
+    amount: 1_500_000n,
+    token: mockUSDC,
+    expected: '1.50 USDC',
+  },
+  {
+    name: 'USDC: 123,456 (0.123456 USDC)',
+    amount: 123_456n,
+    token: mockUSDC,
+    expected: '0.123456 USDC',
+  },
+  {
+    name: 'WETH: 1 ETH',
+    amount: 1_000_000_000_000_000_000n,
+    token: mockWETH,
+    expected: '1 WETH',
+  },
+  {
+    name: 'WETH: 0.5 ETH',
+    amount: 500_000_000_000_000_000n,
+    token: mockWETH,
+    expected: '0.50 WETH',
+  },
+  {
+    name: 'WETH: 1.234 ETH',
+    amount: 1_234_000_000_000_000_000n,
+    token: mockWETH,
+    expected: '1.234 WETH',
+  },
+  {
+    name: 'MAX_UINT256 shows Unlimited',
+    amount: MAX_UINT256,
+    token: mockUSDC,
+    expected: 'Unlimited USDC',
+  },
+  {
+    name: 'Zero amount',
+    amount: 0n,
+    token: mockWETH,
+    expected: '0 WETH',
+  },
+];
+
+console.log('=== Token Registry Tests ===\n');
+console.log('--- formatAmount Tests ---\n');
+
+let passed = 0;
+let failed = 0;
+
+for (const tc of formatTestCases) {
+  const result = formatAmount(tc.amount, tc.token);
+  const match = result === tc.expected;
+
+  console.log(`Test: ${tc.name}`);
+  console.log(`  Result: "${result}"`);
+  console.log(`  Expected: "${tc.expected}"`);
+  console.log(`  Status: ${match ? 'PASS ✓' : 'FAIL ✗'}\n`);
+
+  if (match) passed++;
+  else failed++;
+}
+
+console.log('=== Summary ===');
+console.log(`Passed: ${passed}/${passed + failed}`);
+console.log(`Failed: ${failed}/${passed + failed}`);
+
+// Note about async tests
+console.log('\n--- Notes ---');
+console.log('getToken() and isToken() require network access to test.');
+console.log('They fetch from Uniswap Token List API and cache in localStorage.');
+
+process.exit(failed > 0 ? 1 : 0);

--- a/src/services/token/index.ts
+++ b/src/services/token/index.ts
@@ -1,8 +1,223 @@
-// Placeholder for token registry service - implemented in Issue #8
-export function getToken() {
-  // TODO: Implement token registry
+import type { Address, ChainId, TokenInfo } from '@/types';
+
+const UNISWAP_TOKEN_LIST_URL =
+  'https://tokens.uniswap.org';
+
+const CACHE_KEY = 'tx-decoder-token-cache';
+const CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours
+
+// MAX_UINT256 for detecting unlimited approvals
+const MAX_UINT256 = 2n ** 256n - 1n;
+
+interface TokenCache {
+  tokens: Map<string, TokenInfo>;
+  timestamp: number;
 }
 
-export function formatAmount() {
-  // TODO: Implement amount formatter
+interface TokenListResponse {
+  tokens: Array<{
+    chainId: number;
+    address: string;
+    symbol: string;
+    name: string;
+    decimals: number;
+    logoURI?: string;
+  }>;
+}
+
+// In-memory cache
+let tokenCache: TokenCache | null = null;
+
+/**
+ * Generate cache key for a token
+ */
+function getCacheKey(address: Address, chainId: ChainId): string {
+  return `${chainId}:${address.toLowerCase()}`;
+}
+
+/**
+ * Load token cache from localStorage
+ */
+function loadCache(): TokenCache | null {
+  try {
+    const cached = localStorage.getItem(CACHE_KEY);
+    if (!cached) return null;
+
+    const parsed = JSON.parse(cached);
+    if (Date.now() - parsed.timestamp > CACHE_TTL) {
+      localStorage.removeItem(CACHE_KEY);
+      return null;
+    }
+
+    // Convert array back to Map
+    const tokens = new Map<string, TokenInfo>(parsed.tokens);
+    return { tokens, timestamp: parsed.timestamp };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save token cache to localStorage
+ */
+function saveCache(cache: TokenCache): void {
+  try {
+    const serializable = {
+      tokens: Array.from(cache.tokens.entries()),
+      timestamp: cache.timestamp,
+    };
+    localStorage.setItem(CACHE_KEY, JSON.stringify(serializable));
+  } catch {
+    // localStorage might be full or unavailable
+  }
+}
+
+/**
+ * Fetch tokens from Uniswap Token List
+ */
+async function fetchTokenList(): Promise<Map<string, TokenInfo>> {
+  const tokens = new Map<string, TokenInfo>();
+
+  try {
+    const response = await fetch(UNISWAP_TOKEN_LIST_URL);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch token list: ${response.status}`);
+    }
+
+    const data: TokenListResponse = await response.json();
+
+    for (const token of data.tokens) {
+      // Only include supported chains
+      const chainId = token.chainId as ChainId;
+      if (![1, 10, 137, 42161, 8453, 43114, 56].includes(chainId)) {
+        continue;
+      }
+
+      const tokenInfo: TokenInfo = {
+        address: token.address.toLowerCase() as Address,
+        chainId,
+        symbol: token.symbol,
+        name: token.name,
+        decimals: token.decimals,
+        logoURI: token.logoURI,
+      };
+
+      const key = getCacheKey(tokenInfo.address, chainId);
+      tokens.set(key, tokenInfo);
+    }
+  } catch (error) {
+    console.error('Failed to fetch token list:', error);
+  }
+
+  return tokens;
+}
+
+/**
+ * Initialize or refresh the token cache
+ */
+async function ensureCache(): Promise<TokenCache> {
+  if (tokenCache) {
+    return tokenCache;
+  }
+
+  // Try to load from localStorage
+  const cached = loadCache();
+  if (cached) {
+    tokenCache = cached;
+    return tokenCache;
+  }
+
+  // Fetch fresh data
+  const tokens = await fetchTokenList();
+  tokenCache = { tokens, timestamp: Date.now() };
+  saveCache(tokenCache);
+
+  return tokenCache;
+}
+
+/**
+ * Get token info by address and chainId.
+ * Returns null if token is not found.
+ */
+export async function getToken(
+  address: Address,
+  chainId: ChainId
+): Promise<TokenInfo | null> {
+  const cache = await ensureCache();
+  const key = getCacheKey(address, chainId);
+  return cache.tokens.get(key) ?? null;
+}
+
+/**
+ * Get multiple tokens at once.
+ */
+export async function getTokens(
+  addresses: Address[],
+  chainId: ChainId
+): Promise<Map<Address, TokenInfo>> {
+  const cache = await ensureCache();
+  const result = new Map<Address, TokenInfo>();
+
+  for (const address of addresses) {
+    const key = getCacheKey(address, chainId);
+    const token = cache.tokens.get(key);
+    if (token) {
+      result.set(address.toLowerCase() as Address, token);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Format a token amount with proper decimals and symbol.
+ * Shows "Unlimited" for MAX_UINT256 (common in approvals).
+ */
+export function formatAmount(amount: bigint, token: TokenInfo): string {
+  // Check for unlimited approval
+  if (amount === MAX_UINT256) {
+    return `Unlimited ${token.symbol}`;
+  }
+
+  // Format with decimals
+  const divisor = 10n ** BigInt(token.decimals);
+  const wholePart = amount / divisor;
+  const fractionalPart = amount % divisor;
+
+  // Format fractional part with proper padding
+  let fractionalStr = fractionalPart.toString().padStart(token.decimals, '0');
+  // Trim trailing zeros but keep at least 2 decimal places for readability
+  fractionalStr = fractionalStr.replace(/0+$/, '');
+  if (fractionalStr.length < 2 && fractionalStr.length > 0) {
+    fractionalStr = fractionalStr.padEnd(2, '0');
+  }
+
+  if (fractionalStr) {
+    return `${wholePart.toLocaleString()}.${fractionalStr} ${token.symbol}`;
+  }
+
+  return `${wholePart.toLocaleString()} ${token.symbol}`;
+}
+
+/**
+ * Check if an address is a known token.
+ */
+export async function isToken(
+  address: Address,
+  chainId: ChainId
+): Promise<boolean> {
+  const token = await getToken(address, chainId);
+  return token !== null;
+}
+
+/**
+ * Clear the token cache (useful for testing or forced refresh)
+ */
+export function clearCache(): void {
+  tokenCache = null;
+  try {
+    localStorage.removeItem(CACHE_KEY);
+  } catch {
+    // Ignore errors
+  }
 }


### PR DESCRIPTION
- Fetch tokens from Uniswap Token List API
- Cache in localStorage with 24h TTL
- getToken(address, chainId) returns TokenInfo
- formatAmount(amount, token) formats with symbol
- MAX_UINT256 shows as "Unlimited" for approvals
- Fix eslint config to ignore .vite cache
- Add test script with 8 passing test cases

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)